### PR TITLE
Iconv no more needed in ProcessedByRoo

### DIFF
--- a/lib/remote_table/processed_by_roo.rb
+++ b/lib/remote_table/processed_by_roo.rb
@@ -6,27 +6,25 @@ class RemoteTable
 
     # Yield each row using Roo.
     def _each
-      # sometimes Roo forgets to require iconv.
-      require 'iconv'
       require 'roo'
 
       spreadsheet = roo_class.new local_copy.path, nil, :ignore
       if sheet
         spreadsheet.default_sheet = sheet
       end
-      
+
       first_row = if crop
         crop.first + 1
       else
         skip + 1
       end
-        
+
       last_row = if crop
         crop.last
       else
         spreadsheet.last_row
       end
-      
+
       if not headers
 
         # create an array to represent this row
@@ -48,7 +46,7 @@ class RemoteTable
         end
 
       else
-        
+
         # create a hash to represent this row
         current_headers = ::ActiveSupport::OrderedHash.new
         if headers == :first_row

--- a/remote_table.gemspec
+++ b/remote_table.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
-  
+
   s.add_runtime_dependency 'activesupport', '>=2.3.4'
-  s.add_runtime_dependency 'roo', '>= 1.10.3'
+  s.add_runtime_dependency 'roo', '>= 1.11'
   s.add_runtime_dependency 'fixed_width-multibyte', '>=0.2.3'
   s.add_runtime_dependency 'i18n' # activesupport?
   s.add_runtime_dependency 'unix_utils', '>=0.0.8'


### PR DESCRIPTION
Iconv is deprecated in Ruby 2.0.0 and Roo doesn't need it anymore since version 1.11 (See https://github.com/Empact/roo/pull/19).

This allow to parse spreadsheet with remote_table on Ruby >= 2.0.0
